### PR TITLE
Added initial MQuery scripts to query the Reporting API endpoints (V1)

### DIFF
--- a/powerbi/DeploymentFrequency(V1)-PowerBI-MQuery.pq
+++ b/powerbi/DeploymentFrequency(V1)-PowerBI-MQuery.pq
@@ -7,7 +7,8 @@ let
         "&EndDate={EndDate}T00%3A00%3A00.0000000Z" &
         "&Interval=Daily&GroupBy=TotalDeploymentCount",
     url = Text.Replace(Text.Replace(urlWithoutDates, "{StartDate}", startDate), "{EndDate}", endDate),
-    headers = [ #"Authorization" = "token XXXXX"],
+    gearsetApiToken = "<YourAPITokenHere>", // TODO: Replace this with your Gearset API Token
+    headers = [ #"Authorization" = "token " & gearsetApiToken],
     result = Json.Document(Web.Contents(url, [Headers = headers])),
     Items = result[Items],
     Items1 = Items{0},

--- a/powerbi/DeploymentFrequency(V1)-PowerBI-MQuery.pq
+++ b/powerbi/DeploymentFrequency(V1)-PowerBI-MQuery.pq
@@ -1,0 +1,22 @@
+let
+    // Allow easy switching of the date dynamically to get the last 30 days, on an interval of 'daily' and grouped by TotalDeployments
+    startDate = Date.ToText(Date.AddDays(Date.From(DateTime.LocalNow()), -30), "yyyy-MM-dd"),
+    endDate = Date.ToText(Date.From(DateTime.LocalNow()), "yyyy-MM-dd"),
+    urlWithoutDates = "https://api.gearset.com/public/reporting/deployment-frequency/aggregate" &
+        "?StartDate={StartDate}T00%3A00%3A00.0000000Z" &
+        "&EndDate={EndDate}T00%3A00%3A00.0000000Z" &
+        "&Interval=Daily&GroupBy=TotalDeploymentCount",
+    url = Text.Replace(Text.Replace(urlWithoutDates, "{StartDate}", startDate), "{EndDate}", endDate),
+    headers = [ #"Authorization" = "token XXXXX"],
+    result = Json.Document(Web.Contents(url, [Headers = headers])),
+    Items = result[Items],
+    Items1 = Items{0},
+    #"Converted to Table" = Record.ToTable(Items1),
+    #"Filtered Rows" = Table.SelectRows(#"Converted to Table", each ([Value] <> "count")),
+    #"Expanded Value" = Table.ExpandListColumn(#"Filtered Rows", "Value"),
+    #"Expanded Value1" = Table.ExpandRecordColumn(#"Expanded Value", "Value", {"Date", "Value"}, {"Date", "Value.1"}),
+    #"Renamed Columns" = Table.RenameColumns(#"Expanded Value1",{{"Value.1", "Deployments"}}),
+    #"Removed Columns" = Table.RemoveColumns(#"Renamed Columns",{"Name"}),
+    #"Changed Type" = Table.TransformColumnTypes(#"Removed Columns",{{"Date", type datetime}, {"Deployments", Int64.Type}})
+in
+    #"Changed Type"

--- a/powerbi/DeploymentFrequency(V1)-PowerBI-MQuery.pq
+++ b/powerbi/DeploymentFrequency(V1)-PowerBI-MQuery.pq
@@ -1,4 +1,6 @@
 let
+    gearsetApiToken = "<YourAPITokenHere>", // TODO: Replace this with your Gearset API Token
+
     // Allow easy switching of the date dynamically to get the last 30 days, on an interval of 'daily' and grouped by TotalDeployments
     startDate = Date.ToText(Date.AddDays(Date.From(DateTime.LocalNow()), -30), "yyyy-MM-dd"),
     endDate = Date.ToText(Date.From(DateTime.LocalNow()), "yyyy-MM-dd"),
@@ -6,8 +8,8 @@ let
         "?StartDate={StartDate}T00%3A00%3A00.0000000Z" &
         "&EndDate={EndDate}T00%3A00%3A00.0000000Z" &
         "&Interval=Daily&GroupBy=TotalDeploymentCount",
+        
     url = Text.Replace(Text.Replace(urlWithoutDates, "{StartDate}", startDate), "{EndDate}", endDate),
-    gearsetApiToken = "<YourAPITokenHere>", // TODO: Replace this with your Gearset API Token
     headers = [ #"Authorization" = "token " & gearsetApiToken],
     result = Json.Document(Web.Contents(url, [Headers = headers])),
     Items = result[Items],

--- a/powerbi/LeadTime(V1)-PowerBI-MQuery.pq
+++ b/powerbi/LeadTime(V1)-PowerBI-MQuery.pq
@@ -1,5 +1,5 @@
 let
-    startDate = "2024-01-20",            // TODO: Replace these dates with the range you want to grab the lead time aggregate for
+    startDate = "2024-01-20",            // TODO: Replace these dates (YYYY-MM-DD) with the range you want to grab the lead time aggregate for
     endDate = "2024-07-20",
     pipelineId = "<YourPipelineIDHere>", // TODO: Replace this with your PipelineID
     
@@ -11,8 +11,8 @@ let
     
     // Replace placeholders with actual values in one line
     url = Text.Replace(Text.Replace(Text.Replace(urlWithoutDates, "{PipelineId}", pipelineId), "{StartDate}", startDate), "{EndDate}", endDate),
-    //TODO: Change this to your API token
-    headers = [ #"Authorization" = "token XXXXXX"],
+    gearsetApiToken = "<YourAPITokenHere>", // TODO: Replace this with your Gearset API Token
+    headers = [ #"Authorization" = "token " & gearsetApiToken],
     result = Json.Document(Web.Contents(url, [Headers = headers])),
     Environments = result[Environments],
     Environments1 = Environments{0}, // This grabs the first environment in the list which should be your final org to track against

--- a/powerbi/LeadTime(V1)-PowerBI-MQuery.pq
+++ b/powerbi/LeadTime(V1)-PowerBI-MQuery.pq
@@ -1,7 +1,8 @@
 let
-    startDate = "2024-01-20",            // TODO: Replace these dates (YYYY-MM-DD) with the range you want to grab the lead time aggregate for
+    startDate = "2024-01-20",               // TODO: Replace these dates (YYYY-MM-DD) with the range you want to grab the lead time aggregate for
     endDate = "2024-07-20",
-    pipelineId = "<YourPipelineIDHere>", // TODO: Replace this with your PipelineID
+    pipelineId = "<YourPipelineIDHere>",    // TODO: Replace this with your PipelineID
+    gearsetApiToken = "<YourAPITokenHere>", // TODO: Replace this with your Gearset API Token
     
     // URL template with placeholders for StartDate, EndDate, and PipelineId. Aggregating Weekly
     urlWithoutDates = "https://api.gearset.com/public/reporting/lead-time/{PipelineId}/aggregate" &
@@ -11,7 +12,6 @@ let
     
     // Replace placeholders with actual values in one line
     url = Text.Replace(Text.Replace(Text.Replace(urlWithoutDates, "{PipelineId}", pipelineId), "{StartDate}", startDate), "{EndDate}", endDate),
-    gearsetApiToken = "<YourAPITokenHere>", // TODO: Replace this with your Gearset API Token
     headers = [ #"Authorization" = "token " & gearsetApiToken],
     result = Json.Document(Web.Contents(url, [Headers = headers])),
     Environments = result[Environments],

--- a/powerbi/LeadTime(V1)-PowerBI-MQuery.pq
+++ b/powerbi/LeadTime(V1)-PowerBI-MQuery.pq
@@ -1,0 +1,55 @@
+let
+    startDate = "2024-01-20",            // TODO: Replace these dates with the range you want to grab the lead time aggregate for
+    endDate = "2024-07-20",
+    pipelineId = "<YourPipelineIDHere>", // TODO: Replace this with your PipelineID
+    
+    // URL template with placeholders for StartDate, EndDate, and PipelineId. Aggregating Weekly
+    urlWithoutDates = "https://api.gearset.com/public/reporting/lead-time/{PipelineId}/aggregate" &
+        "?StartDate={StartDate}T00%3A00%3A00.0000000Z" &
+        "&EndDate={EndDate}T00%3A00%3A00.0000000Z" &
+        "&Interval=Weekly",
+    
+    // Replace placeholders with actual values in one line
+    url = Text.Replace(Text.Replace(Text.Replace(urlWithoutDates, "{PipelineId}", pipelineId), "{StartDate}", startDate), "{EndDate}", endDate),
+    //TODO: Change this to your API token
+    headers = [ #"Authorization" = "token XXXXXX"],
+    result = Json.Document(Web.Contents(url, [Headers = headers])),
+    Environments = result[Environments],
+    Environments1 = Environments{0}, // This grabs the first environment in the list which should be your final org to track against
+    MeanTimeLeadTimeForChanges = Environments1[MeanTimeLeadTimeForChanges],
+    #"Converted to Table" = Table.FromList(MeanTimeLeadTimeForChanges, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
+    #"Expanded Column1" = Table.ExpandRecordColumn(#"Converted to Table", "Column1", {"Date", "Value"}, {"Column1.Date", "Column1.Value"}),
+    #"Changed Type" = Table.TransformColumnTypes(#"Expanded Column1", {{"Column1.Date", type datetime}, {"Column1.Value", type text}}),
+    #"Renamed Columns" = Table.RenameColumns(#"Changed Type", {{"Column1.Date", "Date"}, {"Column1.Value", "MeanLeadTime"}}),
+
+    // Define the function to convert DD.HH:MM:SS.MS or HH:MM:SS format to decimal days
+    convertToDecimalDays = (timeSpan as text) as number =>
+        let
+            // Check if timeSpan starts with "00" (indicating hours only)
+            startsWithZero = Text.Start(timeSpan, 2) = "00",
+
+            // Split based on the format
+            parts = if startsWithZero then Text.Split(timeSpan, ":") else Text.Split(timeSpan, "."),
+            
+            // If starts with "00", set days to 0 and extract hours and minutes
+            days = if startsWithZero then 0 else Number.FromText(parts{0}),
+            remainingTime = if startsWithZero then timeSpan else parts{1},
+
+            // Split remaining time into hours, minutes, and seconds
+            timeParts = Text.Split(remainingTime, ":"),
+            hours = Number.FromText(timeParts{0}),
+            minutes = Number.FromText(timeParts{1}),
+
+            // Calculate decimal days
+            decimalDays = days + (hours / 24) + (minutes / 1440),
+
+            // Round to 2 decimal places
+            roundedDecimalDays = Number.Round(decimalDays, 2)
+        in
+            roundedDecimalDays,
+
+    // Add the DecimalDays column by applying the custom function and setting the data type to Fixed Decimal Number for charting
+    #"Added Decimal Days" = Table.AddColumn(#"Renamed Columns", "DecimalDays", each convertToDecimalDays([MeanLeadTime]), type number),
+    #"Converted to Fixed Decimal" = Table.TransformColumnTypes(#"Added Decimal Days", {{"DecimalDays", type number}})
+in
+    #"Converted to Fixed Decimal"


### PR DESCRIPTION
Added initial scripts (currently present [here](https://docs.gearset.com/en/articles/9596583-using-powerbi-with-gearset-s-reporting-api#h_fb1f8c2cac:~:text=API%20Token%3A-,let,-//%20Allow%20easy%20switching)) to query the Deployment Frequency/Lead Time aggregate endpoints from Gearset's Reporting API and transform the data for visualisation.

Variables highlighted for relevant tokens/IDs/timeframes to change as appropriate.