### PR TITLE
Initial commit of SF Code Analyzer v5 integration yml to run in ADO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- omit in toc -->
 # gearset-integrations
 
-This repository provides foundational code snippets for integrating **Gearset** with various external systems, or tools that can be surfaced into Gearset. The examples are intended to demonstrate potential integration approaches and serve as a starting point for customizing Gearset workflows with other tools and services.
+This repository provides foundational code snippets for integrating **Gearset** with various external systems, or tools that can be surfaced in Gearset. The examples are intended to demonstrate potential integration approaches and serve as a starting point for customizing Gearset workflows with other tools and services.
 
 > **Note**: The code snippets in this repository are provided "as-is" under the [Apache 2.0 License](./LICENSE). They are **examples only** and should be tailored to fit your specific requirements. We accept no responsibility or liability for their use.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- omit in toc -->
 # gearset-integrations
 
-This repository provides foundational code snippets for integrating **Gearset** with various external systems. The examples are intended to demonstrate potential integration approaches and serve as a starting point for customizing Gearset workflows with other tools and services.
+This repository provides foundational code snippets for integrating **Gearset** with various external systems, or tools that can be surfaced into Gearset. The examples are intended to demonstrate potential integration approaches and serve as a starting point for customizing Gearset workflows with other tools and services.
 
 > **Note**: The code snippets in this repository are provided "as-is" under the [Apache 2.0 License](./LICENSE). They are **examples only** and should be tailored to fit your specific requirements. We accept no responsibility or liability for their use.
 
@@ -13,6 +13,7 @@ This repository provides foundational code snippets for integrating **Gearset** 
 - [Available Integrations](#available-integrations)
   - [1. Google Sheets](#1-google-sheets)
   - [2. Power BI](#2-power-bi)
+  - [3. Salesforce Code Analyzer in Azure DevOps](#3-salesforce-code-analyzer-in-azure-devops)
 - [Customization](#customization)
 - [License](#license)
 
@@ -39,6 +40,11 @@ To use any of the provided integration snippets:
    - **Description**: Code to synchronize Reporting API information from Gearset into Power BI Desktop, enabling time-defined tracking and reporting for key endpoints.
    - **Example Use Case**: Pull Deployment Frequency information for the last 30 days across the team, or Lead Time over a longer period for a particular Pipeline.
    - **Documentation**: See [here](https://docs.gearset.com/en/articles/9596583-using-powerbi-with-gearset-s-reporting-api) for setup instructions and example usage.
+
+### 3. Salesforce Code Analyzer in Azure DevOps
+   - **Description**: A .yml file to integrate [Salesforce Code Analyzer](https://developer.salesforce.com/docs/platform/salesforce-code-analyzer/guide/code-analyzer.html) into your Azure DevOps repository, to trigger and scan Pull Requests (PRs) and save the results.
+   - **Example Use Case**: Customers wanting to integrate Salesforce Code Analyzer [v5](https://github.com/forcedotcom/sfdx-scanner) into their Azure DevOps repository to run on PRs, which would then surface in Gearset Pipelines.
+   - **Documentation**: See [here](devopslaunchpad.com/blog/salesforce-code-analyzer) for setup instructions inside Azure DevOps and how that would feed into Gearset.
 
 ## Customization
 

--- a/ado/sfca/SFCAPipeline-v5.yml
+++ b/ado/sfca/SFCAPipeline-v5.yml
@@ -44,11 +44,14 @@ steps:
             $changes = git diff --name-only --relative --diff-filter=AMCR "$TARGET_BRANCH_NAME...$(SOURCE_BRANCH_NAME)"
             # Work out the changes between the target branch and what we've proposed in the source - doesn't include deletions
             Write-Host $changes
-            $RelevantFilesForScanning = $changes -match '\.cls$|\.trigger$|\.js$|\.html$|\.page$|\.cmp$|\.component$'
+            $RelevantFilesForScanning = $changes | Where-Object { $_ -match '\.(cls|trigger|js|html|page|cmp|component)$' }
             # Expanded to cover apex classes/triggers/pages, and LWC/Aura/Visualforce components too. 
             # TODO: Doesn't cover XML - consider for Flows, but then would run on almost every metadata type which would be inefficient
-            Write-Host "##vso[task.setvariable variable=RELEVANT_FILES_FOUND;]$RelevantFilesForScanning"
-            Write-Host "Set environment variable of 'RELEVANT_FILES_FOUND' to '$RelevantFilesForScanning'"
+            # Convert to Boolean: "true" if there are matches, otherwise "false"
+            $RelevantFilesFound = if ($RelevantFilesForScanning.Count -gt 0) { "true" } else { "false" }
+            # Check if we've found more 1 or more matching file type, so we can set the environment variable to run/skip steps
+            Write-Host "##vso[task.setvariable variable=RELEVANT_FILES_FOUND;]$RelevantFilesFound"
+            Write-Host "Set environment variable of 'RELEVANT_FILES_FOUND' to '$RelevantFilesFound'"
             # Set an environment variable to be TRUE or FALSE
             if (($changes -is [string]) -and ($RelevantFilesForScanning)){ 
               Write-Host "Single file found - copying"
@@ -94,7 +97,8 @@ steps:
     condition: eq(variables['RELEVANT_FILES_FOUND'], 'true') # Only run this if we have valid files to scan
   - script: |
       sf code-analyzer run --workspace '$(Build.ArtifactStagingDirectory)/**' --output-file '$(Build.ArtifactStagingDirectory)/SFCAv5Results.html'
-    # Scan the directory of changed files from the initial PowerShell, letting it dynamically decide engines, and output to html
+    # Scan the directory of changed files from the initial PowerShell, letting it dynamically decide engines for RECOMMENDED rules only, and output to html
+    # We could, in future, specify '--rule-selector all' here for all rules from all engines, or specify on threshold using '--severity-threshold 3' to filter
     displayName: 'Run Salesforce Code Analyzer v5 beta'
     condition: eq(variables['RELEVANT_FILES_FOUND'], 'true') # Only run this if we have valid files to scan
   - task: PublishPipelineArtifact@1

--- a/ado/sfca/SFCAPipeline-v5.yml
+++ b/ado/sfca/SFCAPipeline-v5.yml
@@ -1,0 +1,181 @@
+pr:                               # NOTE - This section is overruled in ADO by Build Validation rules on the Branch Policies
+  branches:                       # The triggering branches here listed for PR must exist in your repo, but actually triggering the Pipeline requires a Build Validation rule
+    include:                      # This section could be removed in place of those Build Validation rules, but keeps it consistent with other yml files and gives visibility into the triggering branches
+      - uat                       # More information here - https://learn.microsoft.com/en-us/azure/devops/pipelines/troubleshooting/troubleshoot-triggers?view=azure-devops#ui-settings-override-yaml-trigger-setting:~:text=for%20your%20repo.-,Pull,-request%20triggers%20not
+
+pool:
+  vmImage: ubuntu-latest          # Which VM to use to run this Pipeline
+
+variables:
+    - name: SOURCE_BRANCH_NAME    # What's the source branch name, replaced with 'origin' for git diff-ing - not user-updatable
+      value: $[replace(variables['System.PullRequest.SourceBranch'], 'refs/heads/', 'origin/')]
+    - name: RELEVANT_FILES_FOUND  # Are there relevant files in the PR that SFCA wants to scan? default false - not user-updatable
+      value: false
+    - name: VIOLATIONS_EXCEEDED   # Default value of false as we don't know if violations found are more than max yet - default false - not user-updatable
+      value: false
+    - name: SYSTEM_ACCESSTOKEN    # Access token needed to query the API and post the status back to the PR - not user-updatable
+      value: $(System.AccessToken)
+    - name: STOP_ON_VIOLATIONS    # Do we want to fail the build if violations exceed the max - default true - can be updated
+      value: true
+    - name: MAXIMUM_VIOLATIONS    # What are the maximum amount of violations we'll accept before failing - default 10 - can be updated
+      value: 10 
+
+steps:
+  - task: PowerShell@2
+  # PowerShell script to find all changed files between source/target branch and copy into a folder for scanning since the SF scanner expects a directory to scan
+    displayName: PowerShell - Find delta files and analyze
+    inputs:
+      targetType: 'inline'
+      script: |
+         $targetfolder = "$(Build.StagingDirectory)" + "/" 
+         function Copy-Files {
+             param( [string]$source )
+             $target = $targetfolder + $source
+             New-Item $target -Force 
+             Copy-Item $source $target -Force
+         }
+         # Create an area inside ADO to publish the Artefacts (files & scanner results)
+         $BUILD_REASON = $env:BUILD_REASON # Find the exact build reason (PR vs IndividualCI run)
+         Write-Host "Build reason is - '$BUILD_REASON'"
+         if($BUILD_REASON -match 'PullRequest') {
+            $TARGET_BRANCH_NAME = "origin/$($env:SYSTEM_PULLREQUEST_TARGETBRANCHNAME)"
+            Write-Host "This build is triggered by a PullRequest - Source branch name is $(SOURCE_BRANCH_NAME) and target is $TARGET_BRANCH_NAME"
+            Write-Host "git diff command will include a --diff-filter of - 'AMCR $TARGET_BRANCH_NAME...$(SOURCE_BRANCH_NAME)'"
+            $changes = git diff --name-only --relative --diff-filter=AMCR "$TARGET_BRANCH_NAME...$(SOURCE_BRANCH_NAME)"
+            # Work out the changes between the target branch and what we've proposed in the source - doesn't include deletions
+            Write-Host $changes
+            $RelevantFilesForScanning = $changes -match '\.cls$|\.trigger$|\.js$|\.html$|\.page$|\.cmp$|\.component$'
+            # Expanded to cover apex classes/triggers/pages, and LWC/Aura/Visualforce components too. 
+            # TODO: Doesn't cover XML - consider for Flows, but then would run on almost every metadata type which would be inefficient
+            Write-Host "##vso[task.setvariable variable=RELEVANT_FILES_FOUND;]$RelevantFilesForScanning"
+            Write-Host "Set environment variable of 'RELEVANT_FILES_FOUND' to '$RelevantFilesForScanning'"
+            # Set an environment variable to be TRUE or FALSE
+            if (($changes -is [string]) -and ($RelevantFilesForScanning)){ 
+              Write-Host "Single file found - copying"
+              Copy-Files $changes # Copy individual file into the directory
+            }
+            elseif(($changes -is [array]) -and ($RelevantFilesForScanning)) {      
+              Write-Host "Multiple files found - copying"
+              foreach ($change in $changes){ Copy-Files $change } # Copy those changed files into a directory so they can be scanned as 1 folder and referenced in future
+            }
+            else {
+              Write-Host "No relevant changed files found - variable RELEVANT_FILES_FOUND is false, and skipping all other steps"
+              # Since we have nothing valid to scan, write this log and then everything else will be skipped (including the Status Check POST back to the PR)
+            }
+          }
+          else {
+            Write-Host "Not in a PullRequest - can't check target branch for delta" # This Pipeline won't function as a standalone run since it needs a PR, so skip everything else
+          }
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)
+      artifactName: MyChangedFiles
+    displayName: 'Save changed files to the Artifact directory'
+    condition: eq(variables['RELEVANT_FILES_FOUND'], 'true') # Only run this if we have valid files to scan
+  - task: UseNode@1
+    inputs:
+      version: '22.x'  # Use the latest stable version of Node.js 22
+      checkLatest: true
+    displayName: 'Install NodeJS'
+    condition: eq(variables['RELEVANT_FILES_FOUND'], 'true') # Only run this if we have valid files to scan
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.10'
+      addToPath: true
+    displayName: 'Ensure Python 3.10+ is Available'
+    condition: eq(variables['RELEVANT_FILES_FOUND'], 'true') # Only run this if we have valid files to scan
+  - script: | 
+      npm install -g @salesforce/cli@latest 
+    displayName: 'Install Salesforce CLI' # Latest version compared to older SFDX style
+    condition: eq(variables['RELEVANT_FILES_FOUND'], 'true') # Only run this if we have valid files to scan
+  - script: |
+      sf plugins install code-analyzer@latest
+    displayName: 'Install Salesforce Code Analyzer (v5) Plugin' # Install the v5 beta version
+    condition: eq(variables['RELEVANT_FILES_FOUND'], 'true') # Only run this if we have valid files to scan
+  - script: |
+      sf code-analyzer run --workspace '$(Build.ArtifactStagingDirectory)/**' --output-file '$(Build.ArtifactStagingDirectory)/SFCAv5Results.html'
+    # Scan the directory of changed files from the initial PowerShell, letting it dynamically decide engines, and output to html
+    displayName: 'Run Salesforce Code Analyzer v5 beta'
+    condition: eq(variables['RELEVANT_FILES_FOUND'], 'true') # Only run this if we have valid files to scan
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)/SFCAv5Results.html'
+      artifactName: 'salesforce-code-analyzer-results'
+    displayName: 'Save the SFCAv5Results.html file to the Artifact directory'
+    condition: eq(variables['RELEVANT_FILES_FOUND'], 'true') # Only run this if we have valid files to scan
+  
+  - task: PowerShell@2
+  # PowerShell script to see if violations have been found in the HTML file and if they exceed our maximum violations limit
+    displayName: PowerShell - Assess SFCA Results HTML for errors
+    inputs:
+      targetType: 'inline'
+      script: |
+          $SFCAHTMLOutput = Get-Content -Path "$(Build.ArtifactStagingDirectory)/SFCAv5Results.html" -Raw
+          $totalViolations = 0
+          # Regular expression to match the new JSON-like structure for violation counts
+          $violationsPattern = '"violationCounts":{(.*?)}'
+          if ($SFCAHTMLOutput -match $violationsPattern) {
+            # Extract the JSON object for violation counts
+            $violationCounts = $matches[1]
+            # Parse the total
+            if ($violationCounts -match '"total":(\d+)') {
+                $totalViolations = [int]$matches[1]
+            }
+            Write-Host "Total Code Violations: '$totalViolations'"
+            Write-Host "##vso[task.setvariable variable=totalViolations]$totalViolations" # Set the totalViolations variable to the number found
+            if (($totalViolations -gt $(MAXIMUM_VIOLATIONS)) -and ("$(STOP_ON_VIOLATIONS)" -eq "true")) {
+              Write-Host "Too many violations '$totalViolations' found - above the threshold of '$(MAXIMUM_VIOLATIONS)'"
+              Write-Host "Failing the build. See the HTML file in Published Artefacts for details"
+              Write-Host "##vso[task.setvariable variable=VIOLATIONS_EXCEEDED]true"
+            }
+            else {
+              Write-Host "Violations '$totalViolations' found but STOP_ON_VIOLATIONS is false so passing"
+            }
+          } else {
+            Write-Host "No violations found in the HTML file or the pattern did not match - VIOLATIONS_EXCEEDED staying as-is."
+            Write-Host "##vso[task.setvariable variable=totalViolations]$totalViolations" # Will default to 0 here as we need this variable later
+          }
+    condition: eq(variables['RELEVANT_FILES_FOUND'], 'true') # Only run this if we have valid files to scan
+  - task: PowerShell@2
+    displayName: 'POST Status to Pull Request' # If we've found valid files to scan, POST a result (pass or fail) back to the PR
+    inputs:
+      targetType: 'inline'
+      script: |
+            $repositoryId = "$(Build.Repository.ID)"
+            $pullRequestId = "$(System.PullRequest.PullRequestId)"
+            $accessToken = "$(SYSTEM_ACCESSTOKEN)"
+            $totalViolations = "$(totalViolations)"
+            $escapedProject = [System.Uri]::EscapeDataString("$(System.TeamProject)")
+            $buildUrl = "$(System.TeamFoundationCollectionUri)$escapedProject/_build/results?buildId=$(Build.BuildId)"
+            # Escape the BuildURL and Project name to handle spaces and special characters in there
+            $statusState = if("$(VIOLATIONS_EXCEEDED)" -eq 'true') { "failed" } else { "succeeded" }
+            $status = @{
+              "state" = $statusState
+              "description" = "Code analysis completed with $totalViolations violations. View build details at: $buildUrl"
+              "targetUrl" = $buildUrl
+              "context" = @{
+                "name" = "Salesforce Code Analyzer - Scan"
+                "genre" = "SFCAPipeline"
+              }
+            }
+            $statusJson = $status | ConvertTo-Json -Compress
+            Write-Host "Organization is '$(System.TeamFoundationCollectionUri)' and project is '$escapedProject'"
+            $url = "$(System.TeamFoundationCollectionUri)$escapedProject/_apis/git/repositories/$repositoryId/pullRequests/$pullRequestId/statuses?api-version=7.1-preview.1"
+            Write-Host "Posting status to pull request at URL: '$url' with status JSON of: '$statusJson'"
+            $headers = @{
+              "Content-Type" = "application/json"
+              "Authorization" = "Bearer $accessToken"
+            }
+            $response = Invoke-RestMethod -Uri $url -Method Post -Headers $headers -Body $statusJson
+            Write-Host "Posted status to pull request: $($response.context.name) - $($response.state)"
+            if($statusState -eq "succeeded") { 
+              Write-Host "Overall status is succeeded as we have '$totalViolations' violations and VIOLATIONS_EXCEEDED is false - build passed and status updated on the PR"
+              exit 0  # Exit 'cleanly' as our total violations are less than the threshold or we're not stopping if violations are found
+            }
+            else {
+              Write-Error "Overall status is failed due to '$totalViolations' violations being above the threshold of '$(MAXIMUM_VIOLATIONS)' - failing the entire build and status updated on the PR"
+              exit 1  # If our status is failed, failed the entire build so policy blocks us from merging
+            }
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    condition: eq(variables['RELEVANT_FILES_FOUND'], 'true') # Only run this if we have valid files to scan. 


### PR DESCRIPTION
Added the initial yml file to integrate SFCA v5 into ADO, after thorough testing on various test PRs with different metadata.
Includes several key stages:

- Spin up a runner and configure global variables for the script
- Work out the changed files in the PR using PowerShell/git to feed them into SFCA, as that CLI expects a arg list of files to scan, or a recursive target
- If there's valid file extensions to scan, begin install of necessary pre req packages and the SF CLI/Code Analyzer packages
- Run the scanner and output the findings to a html report, available in ADO as an artefact
- Check the report for total number of violations so we can 'fail' the build if exceeded
- POST a new status check back to the PR with those findings using the right access tokens and build ID

There will likely be further tweaks in coming weeks (couple of TODOs, excessive logging etc) but bulk of the logic all tested and working
